### PR TITLE
moved NODE_ENV to spawn command

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -30,7 +30,7 @@ end
 
 if options[:assets]
   command = "yarn run build"
-  pid = spawn(command, :in => STDIN, :out => STDOUT, :err => STDERR)
+  pid = spawn({'NODE_ENV'=>'production'}, command, :in => STDIN, :out => STDOUT, :err => STDERR)
   Process.wait pid
 end
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "start": "PORT=8080 concurrently \"node bin/assets.js development\" \"serve ./tmp\" --kill-others --prefix-colors=yellow.dim,cyan.dim",
-    "build": "NODE_ENV=production node bin/assets.js production"
+    "build": "node bin/assets.js production"
   },
   "devDependencies": {
     "chalk": "^4.1.0",


### PR DESCRIPTION
The original NODE_ENV in package.json didn't work in windows.  Moving NODE_ENV setting to the SPAWN command works. 